### PR TITLE
Fix version parsing when having `iOSSupportVersion` in the plist

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,15 @@ let version;
 
 const clean = version => version.split('.').length === 2 ? `${version}.0` : version;
 
+const parseVersion = plist => {
+	const matches = /<key>ProductVersion<\/key>[\s]*<string>([\d.]+)<\/string>/.exec(plist);
+	if (!matches) {
+		return;
+	}
+
+	return matches[1];
+};
+
 const getVersion = () => {
 	if (!isMacOS) {
 		return;
@@ -14,13 +23,13 @@ const getVersion = () => {
 
 	if (!version) {
 		const file = fs.readFileSync('/System/Library/CoreServices/SystemVersion.plist', 'utf8');
-		const matches = /<key>ProductVersion<\/key>[\s\S]*<string>([\d.]+)<\/string>/.exec(file);
+		const matches = parseVersion(file);
 
 		if (!matches) {
 			return;
 		}
 
-		version = matches[1];
+		version = matches;
 	}
 
 	if (version) {
@@ -32,6 +41,7 @@ module.exports = getVersion;
 
 const x = module.exports;
 
+x.parseVersion = parseVersion;
 x.isMacOS = isMacOS;
 
 x.is = input => {

--- a/test.js
+++ b/test.js
@@ -8,6 +8,30 @@ test('main', t => {
 	t.is(semver.valid(version), version);
 });
 
+test('main with ios support', t => {
+	const plist = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>ProductBuildVersion</key>
+	<string>18C54</string>
+	<key>ProductCopyright</key>
+	<string>1983-2018 Apple Inc.</string>
+	<key>ProductName</key>
+	<string>Mac OS X</string>
+	<key>ProductUserVisibleVersion</key>
+	<string>10.14.2</string>
+	<key>ProductVersion</key>
+	<string>10.14.2</string>
+	<key>iOSSupportVersion</key>
+	<string>12.0</string>
+</dict>
+</plist>`;
+	const version = m.parseVersion(plist);
+	t.is(semver.valid(version), version);
+	t.is(version, '10.14.2');
+});
+
 test('.is()', t => {
 	t.true(m.is('>=10.10'));
 	t.true(m.is('>=10.10.2'));


### PR DESCRIPTION
The regex matched the last `<string />`, so when running this module on my machine I got that it was running `12.0`